### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,10 +19,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 7.4]
-        laravel: [8.*, 7.*]
+        php: [8.1, 8.0, 7.4]
+        laravel: [9.*, 8.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "illuminate/contracts": "^7.0 || ^8.0",
-        "illuminate/database": "^7.0 || ^8.0",
-        "illuminate/support": "^7.0 || ^8.0"
+        "illuminate/contracts": "^7.0 || ^8.0 || ^9.0",
+        "illuminate/database": "^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0",
+        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for Laravel 9 but expanding the version constraints in `composer.json`.

The test suite is passing when run with Laravel 9.