### PR TITLE
Add support for using a custom DAG Edge model

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,31 @@ $ancestors = MyModel::dagAncestorsOf($myModel->id, 'my-source', 1)->get();
 
 Not providing the `$maxHops` parameter means that all descendants, ancestors, or relations will be returned.
 
+### Custom DAG edge model
+
+You can use your own model class if you need to customise the behaviour of the DAG edge model.
+
+Your custom model class must extend the `Telkins\Models\DagEdge` class:
+
+```php
+namespace App\Models;
+
+use Telkins\Models\DagEdge as BaseModel;
+
+class MyDagEdge extends BaseModel
+{
+...
+```
+
+You can then specify the fully qualified class name of your custom model in the package config file.
+
+```php
+// config/laravel-dag-manager.php
+...
+'edge_model' => \App\Models\MyDagEdge::class,
+...
+```
+
 ## Testing
 
 ```bash

--- a/config/laravel-dag-manager.php
+++ b/config/laravel-dag-manager.php
@@ -44,4 +44,14 @@ return [
 
     'table_name' => 'dag_edges',
 
+    /**
+     *-------------------------------------------------------------------------
+     * Edge Model
+     *-------------------------------------------------------------------------
+     *
+     * The fully qualified class name of the DAG edge model.
+     */
+
+    'edge_model' => \Telkins\Dag\Models\DagEdge::class,
+
 ];

--- a/src/Tasks/AddDagEdge.php
+++ b/src/Tasks/AddDagEdge.php
@@ -51,7 +51,9 @@ class AddDagEdge
 
     protected function edgeExists(): bool
     {
-        return DagEdge::where([
+        $edgeClass = config('laravel-dag-manager.edge_model');
+
+        return $edgeClass::where([
                 ['start_vertex', $this->startVertex],
                 ['end_vertex', $this->endVertex],
                 ['hops', 0],
@@ -68,7 +70,9 @@ class AddDagEdge
             throw new CircularReferenceException();
         }
 
-        if (DagEdge::where([
+        $edgeClass = config('laravel-dag-manager.edge_model');
+
+        if ($edgeClass::where([
                 ['start_vertex', $this->endVertex],
                 ['end_vertex', $this->startVertex],
                 ['source', $this->source],
@@ -92,7 +96,9 @@ class AddDagEdge
 
     protected function createDirectEdge(): DagEdge
     {
-        $edge = DagEdge::create([
+        $edgeClass = config('laravel-dag-manager.edge_model');
+
+        $edge = $edgeClass::create([
             'start_vertex' => $this->startVertex,
             'end_vertex'   => $this->endVertex,
             'hops'         => 0,
@@ -187,7 +193,9 @@ class AddDagEdge
 
     protected function getNewlyInsertedEdges(DagEdge $edge): Collection
     {
-        return DagEdge::where('direct_edge_id', $edge->id)
+        $edgeClass = config('laravel-dag-manager.edge_model');
+
+        return $edgeClass::where('direct_edge_id', $edge->id)
             ->orderBy('hops')
             ->get();
     }

--- a/src/Tasks/RemoveDagEdge.php
+++ b/src/Tasks/RemoveDagEdge.php
@@ -30,7 +30,9 @@ class RemoveDagEdge
      */
     public function execute(): bool
     {
-        $edge = DagEdge::where([
+        $edgeClass = config('laravel-dag-manager.edge_model');
+
+        $edge = $edgeClass::where([
             ['start_vertex', $this->startVertex],
             ['end_vertex', $this->endVertex],
             ['hops', 0],


### PR DESCRIPTION
This PR adds support for using a custom DAG Edge model - allowing users of the package to customise the functionality.

Our particular use case for having a custom model is to disable the Eloquent timestamps.

The test suite passes and instructions for use have been added to the README.

Accepting this PR in its current state would introduce a breaking change as existing package users wouldn't have a value for the `laravel-dag-manager.edge_model` config option. If you don't want to tag a new major release, I guess this could be mitigated by using `Telkins\Models\DagEdge:class` as a default value when retrieving the config value - e.g.:

```php
$edgeClass = config('laravel-dag-manager.edge_model', \Telkins\Models\DagEdge:class);
```

I'd be happy to update the PR to do this if you wish.

