### PR TITLE
add getTable to dagEdge Model

### DIFF
--- a/src/Models/DagEdge.php
+++ b/src/Models/DagEdge.php
@@ -39,4 +39,9 @@ class DagEdge extends Model
     {
         return $this->defaultTableName();
     }
+
+    public function getTable()
+    {
+        return $this->defaultTableName();
+    }
 }


### PR DESCRIPTION
If dag table is created with different name from config, `dagEdge` model will try to get records by `className` (`dag_edges`).
We can add getTable to fix this bug, as it is described in [ Laravel API].(https://laravel.com/api/9.x/Illuminate/Database/Eloquent/Model.html#method_getTable)