### PR TITLE
add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,12 +20,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.3
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Laravel 13 support
+- PHP 8.5 support
+
 ### Changed
-- ...
+- Require PHP 8.3 or higher
+- Test against Laravel 12 and 13 (orchestra/testbench 10 and 11) and PHP 8.3, 8.4, and 8.5
 
 ## [v1.0.0] - 2021-01-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $deleted = dag()->deleteEdge($startVertex, $endVertex, $source);
 
 ## Installation
 
-The latest version of this package requires PHP 8.2 or higher as well as Laravel 12.0 or higher.
+The latest version of this package requires PHP 8.3 or higher as well as Laravel 12.0 or higher (Laravel 12 and 13 are supported).
 
 You can install the package via composer:
 

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^12.0",
-        "illuminate/database": "^12.0",
-        "illuminate/support": "^12.0",
+        "php": "^8.3",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "spatie/laravel-data": "^4.6"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^12.0"
+        "orchestra/testbench": "^10.0|^11.0",
+        "phpunit/phpunit": "^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Support Laravel 13 alongside 12 and test against PHP 8.5. Raises the
  minimum PHP to 8.3 (required by Laravel 13).

  - composer.json: require php ^8.3; illuminate/* ^12.0|^13.0;
    orchestra/testbench ^10.0|^11.0; phpunit/phpunit ^12.0|^13.0
  - CI: matrix covers Laravel 12 + 13 over PHP 8.3/8.4/8.5
    (testbench 10↔L12, 11↔L13; L13 excluded on 8.3)
  - README: note PHP 8.3+ and Laravel 12/13
  - CHANGELOG: document the upgrade